### PR TITLE
Create a script that publishes documentation to gh-pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+publish-docs:
+	git checkout -b gh-pages
+	npm run generate-docs
+	git add -f docs/
+	git add -f ./node_modules/can
+	git add -f ./node_modules/steal
+	git commit -m "Publish docs"
+	git push -f origin gh-pages 
+	git checkout -
+	git branch -D gh-pages

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ in your browser and follow the instructions.
 
 Your finished! Explore some of the app's features:
 
-- Live reload (`npm develop`)
+- Live reload (`npm run develop`)
 - Run the tests (`npm test`)
-- *(coming soon)* Build the documentation (`npm build`)
+- Generate the documentation (`npm run generate-docs`)
 

--- a/documentjs.json
+++ b/documentjs.json
@@ -2,9 +2,10 @@
 	"sites" : {
 		"docs": {
 			"glob" : {
-				"ignore": ["{node_modules,public/node_modules}/**/*"]
+				"ignore": ["{node_modules,public/node_modules,migrations}/**/*"]
 			},
-			"parent": "bitballs"
+			"parent": "bitballs",
+			"dest": "docs"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node index.js",
     "develop": "node index.js --develop",
     "db-migrate": "dropdb bitballs --if-exists && createdb bitballs && ./node_modules/db-migrate/bin/db-migrate up",
+    "generate-docs": "documentjs -d",
     "test": "cd public/ && npm test",
     "install": "node post_install.js"
   },


### PR DESCRIPTION
Enables a user to run documentjs and push its output to the `gh-pages` branch by running:

```
make publish-docs
```

Also enables a user to generate the docs via: 

```
npm run generate-docs
```

Lastly, a note is added to the README showing how to generate the docs.

Closes #27. 