### PR TITLE
Create a script that publishes documentation to gh-pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+publish-docs:
+	git checkout -b gh-pages
+	donejs document
+	git add -f docs/
+	git add -f public/components/
+	git add -f public/node_modules/jquery
+	git add -f public/node_modules/can
+	git add -f public/node_modules/can-connect
+	git add -f public/node_modules/can-fixture
+	git add -f public/node_modules/can-ssr
+	git add -f public/node_modules/can-set
+	git add -f public/node_modules/bootstrap
+	git add -f public/node_modules/done-autorender
+	git add -f public/node_modules/done-component
+	git add -f public/node_modules/done-css
+	git add -f public/node_modules/donejs-cli
+	git add -f public/node_modules/generator-donejs
+	git add -f public/node_modules/moment
+	git add -f public/node_modules/qunitjs
+	git add -f public/node_modules/steal
+	git add -f public/node_modules/steal-qunit
+	git add -f public/node_modules/steal-systemjs
+	git add -f public/node_modules/steal-es6-module-loader
+	git add -f public/node_modules/when
+	git add -f public/node_modules/yeoman-environment
+	git add -f public/test.html
+	git commit -m "Publish docs"
+	git push -f origin gh-pages 
+	git rm -q -r --cached public/node_modules
+	git checkout -
+	git branch -D gh-pages

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ in your browser and follow the instructions.
 
 Your finished! Explore some of the app's features:
 
-- Live reload (`npm develop`)
-- Run the tests (`npm test`)
-- *(coming soon)* Build the documentation (`npm build`)
+- Live reload (`donejs develop`)
+- Run the tests (`donejs test`)
+- Generate the documentation (`donejs document`)
 

--- a/documentjs.json
+++ b/documentjs.json
@@ -2,9 +2,10 @@
 	"sites" : {
 		"docs": {
 			"glob" : {
-				"ignore": ["{node_modules,public/node_modules}/**/*"]
+				"ignore": ["{node_modules,public/node_modules,migrations}/**/*"]
 			},
-			"parent": "bitballs"
+			"parent": "bitballs",
+			"dest": "docs"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node index.js",
     "develop": "node index.js --develop",
     "db-migrate": "dropdb bitballs --if-exists && createdb bitballs && ./node_modules/db-migrate/bin/db-migrate up",
+    "document": "documentjs -d",
     "test": "cd public/ && npm test",
     "install": "node post_install.js"
   },

--- a/public/components/game/details/details.js
+++ b/public/components/game/details/details.js
@@ -19,7 +19,7 @@
  *
  * ## Sweet example
  * 
- * @demo bitballs/public/components/game/details/details.html
+ * @demo public/components/game/details/details.html
  * 
  */
 

--- a/public/test.html
+++ b/public/test.html
@@ -1,3 +1,3 @@
 <title>bitballs-client tests</title>
-<script src="../node_modules/steal/steal.js" main="test"></script>
+<script src="node_modules/steal/steal.js" main="test"></script>
 <div id="qunit-fixture"></div>


### PR DESCRIPTION
Enables a user to run documentjs and push its output to the `gh-pages` branch by running:

```
make publish-docs
```

Also enables a user to generate the docs via: 

```
npm run generate-docs
```

Lastly, a note is added to the README showing how to generate the docs.

Closes #27. 