### PR TITLE
Remove rank column

### DIFF
--- a/public/components/player/list/list.stache
+++ b/public/components/player/list/list.stache
@@ -8,7 +8,6 @@
 			<th>Age</th>
 			<th>Weight</th>
 			<th>Height</th>
-			<th>Rank</th>
 			<th></th>
 		</tr>
 	</thead>
@@ -29,7 +28,6 @@
 						<td>{{age}}</td>
 						<td>{{weight}}</td>
 						<td>{{height}}</td>
-						<td>{{rank}}</td>
 						<td>
 							{{#if session.isAdmin}}
 								<button type="button" class="btn btn-default" ($click)="editPlayer(.)">


### PR DESCRIPTION
Simply removes the unused markup. There was some mention of `startRank` in the fixtures/migration. not sure if we should remove that also. 

Closes #50. 