### PR TITLE
removing renderingBaseUrl

### DIFF
--- a/public/package.json
+++ b/public/package.json
@@ -49,7 +49,6 @@
     ],
     "envs": {
       "server-production": {
-        "renderingBaseURL": "https://bitballs-donejs.firebaseapp.com/"
       }
     },
     "meta": {


### PR DESCRIPTION
This temporarily removes pointing at the CDN.  

@jandjorgensen please figure out what's wrong and make this work again tomorrow. 