### PR TITLE
Enable a user to delete a stat

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -12,7 +12,7 @@ const AppState = AppMap.extend({
 		pageComponentName: {
 			get: function(){
 				if(this.attr("gameId")) {
-					return "game-details game-id='{gameId}' session='{session}'";
+					return "game-details game-id='{gameId}' session='{.}'";
 
 				} else if(this.attr("teamId")) {
 					return "team-details session='{.}'";

--- a/public/components/game/details/details.js
+++ b/public/components/game/details/details.js
@@ -235,7 +235,12 @@ exports.ViewModel = Map.extend(
 		this.attr("youtubePlayer").playVideo();
 		event && event.stopPropagation();
 	},
-	
+
+	deleteStat: function (stat, el, event) {
+		stat.destroy();
+		event && event.stopPropagation();
+	},
+
 	statPercent: function(time){
 		var duration = this.attr("duration");
 		if(duration) {

--- a/public/components/game/details/details.less
+++ b/public/components/game/details/details.less
@@ -29,10 +29,25 @@ game-details .stat-point {
     border: 1px solid transparent;
     border-radius: 2px;
     transform: translate( -50%, 0);
+
+    .delete-btn {
+        display: none;
+        padding: 2px;
+        font-size: 0.9em;
+        opacity: 0.5;
+
+        &:hover {
+            opacity: 1.0;
+        }
+    }
 }
 game-details .stat-point:hover {
     font-size: 12px;
     padding: 1px;
+
+    .delete-btn {
+        display: inline-block;
+    }
 }
 .youtube-container {
   padding-bottom: 15px;

--- a/public/components/game/details/details.stache
+++ b/public/components/game/details/details.stache
@@ -30,8 +30,13 @@
 			<td>{{name}}</div>
 			<td class="stats-container">
 				{{#eachOf statsForPlayerId(id)}}
-					<span ($click)="gotoTimeMinus5( time, %event)" 
-							class='stat-point stat-{{type}}' style="left: {{statPercent time}}%">{{type}}</span>
+					<span ($click)="gotoTimeMinus5(time, %event)"
+						class="stat-point stat-{{type}}" style="left: {{statPercent time}}%">
+						{{type}}
+						{{#if session.isAdmin}}
+							<span class="destroy-btn glyphicon glyphicon-trash" ($click)="deleteStat"></span>
+						{{/if}}
+					</span>
 				{{/each}}
 			</td>
 		</tr>

--- a/public/components/game/details/details.stache
+++ b/public/components/game/details/details.stache
@@ -34,7 +34,7 @@
 						class="stat-point stat-{{type}}" style="left: {{statPercent time}}%">
 						{{type}}
 						{{#if session.isAdmin}}
-							<span class="destroy-btn glyphicon glyphicon-trash" ($click)="deleteStat"></span>
+							<span class="destroy-btn glyphicon glyphicon-trash" ($click)="deleteStat(., %event)"></span>
 						{{/if}}
 					</span>
 				{{/each}}

--- a/public/components/game/details/details_test.js
+++ b/public/components/game/details/details_test.js
@@ -2,6 +2,11 @@ import QUnit from "steal-qunit";
 import Session from "models/session";
 import details from "./details";
 import fixtureContent from "models/fixtures/games";
+import F from 'funcunit';
+import stache from 'can/view/stache/';
+import fixture from 'can-fixture';
+
+F.attach(QUnit);
 
 var DetailsViewModel = details.ViewModel;
 
@@ -40,5 +45,45 @@ QUnit.test("correctly sums score", function() {
             away: 5
         });
         QUnit.start();
+    });
+});
+
+QUnit.test('A stat can be deleted by an admin', function () {
+
+    var session = new Session({
+        isAdmin: false
+    });
+
+    var frag = stache('<game-details {game-id}="gameId" {session}="session" />')({
+        gameId: this.vm.attr('gameId'),
+        session: session
+    });
+
+    $('#qunit-fixture').html(frag);
+
+    QUnit.stop();
+
+    var vm = $('game-details').viewModel();
+
+    vm.bind('game', function(ev, game) {
+        QUnit.start();
+
+        F('.stat-point')
+            .exists('Stat points exist')
+            .size(6, 'Number of stats is correct')
+            .first()
+            .find('.destroy-btn')
+            .size(0, 'There is no destroy button')
+            .then(function () {
+                session.attr('isAdmin', true);
+                ok(true, 'The user is given admin privileges');
+            })
+            .size(1, 'Destroy button is inserted')
+            .click()
+            .wait(fixture.delay)
+            // For some reason .size(0) doesn't work here
+            .then(function () {
+                equal($(this).closest('tbody').length, 0, 'Stat is removed');
+            });
     });
 });

--- a/public/components/game/details/test.html
+++ b/public/components/game/details/test.html
@@ -1,2 +1,3 @@
 <script src="../../../node_modules/steal/steal.js" main="bitballs/components/game/details/details_test">
 </script>
+<div id="qunit-fixture"></div>

--- a/public/models/fixtures/games.js
+++ b/public/models/fixtures/games.js
@@ -126,4 +126,12 @@ fixture("/services/games/{id}", function(request, response) {
     }
 });
 
+fixture('GET /services/stats', function () {
+    return { data: responseData.stats };
+});
+
+fixture('DELETE /services/stats/{id}', function () {
+    return {};
+});
+
 export default responseData;


### PR DESCRIPTION
- Create a stat destroy button
- Show the destroy button when the stat is hovered
- Highlight the destroy button on hover
- Wrap the destroy button in an `{{#if session.isAdmin}}`
- Test the hiding/showing the destroy button based on `session.isAdmin`
- Test removal of stat after clicking the destroy button

Closes #58