### PR TITLE
Avoid calling getCurrentTime if it isn't defined yet

### DIFF
--- a/public/components/game/details/details.js
+++ b/public/components/game/details/details.js
@@ -551,9 +551,12 @@ exports.Component = Component.extend({
 		 * @description  On window resize, update the position of the cursor in the stats container.
 		 */
 		"{window} resize": function(){
-			var player = this.viewModel.attr("youtubePlayer");
-			var currentTime = player.getCurrentTime();
-			this.updatePosition(currentTime);
+			var player = this.viewModel.attr("youtubePlayer"),
+				currentTime;
+			if (player.getCurrentTime) {
+				currentTime = player.getCurrentTime();
+				this.updatePosition(currentTime);
+			}
 		},
 		/**
 		 * @function


### PR DESCRIPTION
Found this error while viewing the docs with my debugger open:

```
Uncaught TypeError: player.getCurrentTime is not a function
```