### PR TITLE
Moved prepare database above dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,18 +100,10 @@ Clone this repo using git:
 git clone https://github.com/donejs/bitballs.git
 ```
 
-### Install Dependencies
-
-To install the project's JavaScript dependencies run:
+Navigate to the repository's directory
 
 ```
-npm install
-```
-
-Additionally DoneJS's command line utilities need to be installed globally:
-
-```
-npm install -g donejs-cli
+cd bitballs
 ```
 
 ### Prepare the Database
@@ -136,10 +128,18 @@ will persist its data to:
 createdb bitballs
 ```
 
-Next, create the database schema that the application expects by running:
+### Install Dependencies
+
+To install the project's JavaScript dependencies run:
 
 ```
-npm run db-migrate
+npm install
+```
+
+Additionally DoneJS's command line utilities need to be installed globally:
+
+```
+npm install -g donejs-cli
 ```
 
 ### Start the Server


### PR DESCRIPTION
npm install runs db-migrate up and expects bitballs db to be present.

`ps | grep postgres` is not giving expected output on El Capitain.