### PR TITLE
steal 2 upgrade

### DIFF
--- a/public/dev.html
+++ b/public/dev.html
@@ -4,6 +4,6 @@
 	<script>
 		steal = { map: { "can-route-pushstate": "@empty" } };
 	</script>
-	<script src="/node_modules/steal/steal.js"></script>
+	<script src="/node_modules/steal/steal.js" main></script>
 </body>
 </html>

--- a/public/package.json
+++ b/public/package.json
@@ -48,7 +48,7 @@
     "generator-donejs": "2.0.0",
     "jquery": "^3.1.1",
     "moment": "^2.10.6",
-    "steal": "2.0.0-pre.1",
+    "steal": "^2.0.0-pre.1",
     "steal-less": "^1.2.0",
     "steal-platform": "0.0.4",
     "steal-qunit": "^1.0.1",


### PR DESCRIPTION
@matthewp This tries to upgrade to steal but http://localhost:5000/dev.html is not loading.

`npm ls steal` shows `steal@2.0.0-pre.9` for me.

To run, you should be able simply clone this branch and open `dev.html`.  If you need to get postgres setup, the instructions are here: https://github.com/donejs/bitballs/blob/master/README.md and only take a few min.

The test pages do load, so I'm betting this is an issue with done-autorender.

After getting this to work, ideally you could help me look at:

- [ ] getting `ssr` to work
- [ ] turning on `incremental ssr`
- [ ] getting this built and deployed (I'll work on this)