### PR TITLE
345 - NHT: Users shall be able to create stats.

### DIFF
--- a/migrations/20190627103100-add-stats-creator.js
+++ b/migrations/20190627103100-add-stats-creator.js
@@ -1,0 +1,13 @@
+var async = require('async');
+
+exports.up = function(db, callback) {
+	async.series([
+		db.addColumn.bind(db, "stats","creatorId",{type: 'int'})
+	], callback);
+};
+
+exports.down = function(db, callback) {
+	async.series([
+		db.removeColumn.bind(db, "stats","creatorId")
+	], callback);
+};

--- a/models/stat.js
+++ b/models/stat.js
@@ -41,6 +41,16 @@ var Stat = bookshelf.Model.extend(
 	player: function(){
 		var Player = require("./player");
 		return this.belongsTo(Player,"playerId");
+	},
+	/**
+	 * @function
+	 *
+	 * Informs Bookshelf.js that the `creator` property will be a [models/user]
+	 * model with an `id` that matches the `creatorId` specified in the query.
+	 **/
+	creator: function() {
+		var User = require("./user");
+		return this.belongsTo(User, "creatorId");
 	}
 });
 

--- a/public/components/game/details/details.js
+++ b/public/components/game/details/details.js
@@ -225,7 +225,7 @@ export const ViewModel = DefineMap.extend('GameDetailsVM',
 	 * ```
 	 */
 	showStatMenuFor: function(player, element, event){
-		if(!this.session || !this.session.isAdmin()) {
+		if(!this.session.user) {
 			return;
 		}
 		var youtubePlayer = this.youtubePlayer;
@@ -236,7 +236,8 @@ export const ViewModel = DefineMap.extend('GameDetailsVM',
 			time: time,
 			playerId: player.id,
 			gameId: this.game.id,
-			player: player
+			player: player,
+			creatorId: this.session.user.id
 		});
 	},
 	/**
@@ -548,6 +549,9 @@ export const ViewModel = DefineMap.extend('GameDetailsVM',
 		return {
 			top: $(containers[index]).offset().top - first.top + (height/2)
 		};
+	},
+	createdBy: function(stat) {
+		return this.session && (this.session.isAdmin() || stat.creatorId === this.session.user.id);
 	},
 
 	connectedCallback(el) {

--- a/public/components/game/details/details.stache
+++ b/public/components/game/details/details.stache
@@ -31,7 +31,7 @@
 						<span on:click="scope.vm.gotoTimeMinus5(time, scope.event)"
 							class="stat-point stat-{{ type }}" style="left: {{ scope.vm.statPercent(time) }}%">
 							{{ type }}
-							{{# if(scope.vm.session.isAdmin()) }}
+							{{# if(scope.vm.createdBy(this)) }}
 								<span class="destroy-btn glyphicon glyphicon-trash"
 									on:click="scope.vm.deleteStat(this, scope.event)"></span>
 							{{/ if }}

--- a/public/models/stat.js
+++ b/public/models/stat.js
@@ -25,6 +25,7 @@
 import { DefineMap, DefineList, QueryLogic, superModel } from "can";
 import bookshelfService from "./bookshelf-service";
 import Player from "bitballs/models/player";
+import User from "bitballs/models/user";
 
 var Stat = DefineMap.extend('Stat',
 {
@@ -96,6 +97,23 @@ var Stat = DefineMap.extend('Stat',
 			return Math.round(newVal);
 		}
 	},
+	/**
+	 * @property {bitballs/models/user} bitballs/models/stat.properties.creator creator
+	 * @parent bitballs/models/user.properties
+	 *
+	 * User related to the stats
+	 */
+	creator: {
+		Type: User,
+		serialize: false
+	},
+	/**
+	 * @property {Number} bitballs/models/stat.properties.creatorId creatorId
+	 * @parent bitballs/models/stat.properties
+	 * 
+	 * The user that created the stat.
+	 */
+	creatorId: 'number',
 
 	default: 'any'
 });

--- a/services/loggedIn.js
+++ b/services/loggedIn.js
@@ -1,0 +1,15 @@
+module.exports = function( respObj, status ) {
+    if ( typeof respObj === "string" ) {
+        respObj = {
+            message: respObj
+        };
+    }
+
+    return function ( req, res, next ) {
+        if ( req.user ) {
+            next();
+        } else {
+            res.status( status || 404 ).end();
+        }
+    }
+}


### PR DESCRIPTION
- Upgrade DB script adds a creatorId column to the DB.
- Added the creatorId to a stat to capture the user that created the stat.
- Logged in user's can now create stats.
- If a user is logged in they will see the delete icon for stats they created.
- If an admin is logged in they can delete stats that anyone has created.
- Updated the server to delete stats only when the stat was created by the current user or the current user is an admin.
